### PR TITLE
fix: set correct plugin path in Codex installer script

### DIFF
--- a/codex-install.sh
+++ b/codex-install.sh
@@ -53,7 +53,8 @@ data.plugins = data.plugins || [];
 data.plugins = data.plugins.filter(p => p.name !== '${PLUGIN_NAME}');
 data.plugins.push({
     name: '${PLUGIN_NAME}',
-    source: { source: 'local', path: './${PLUGIN_NAME}' },
+    interface: { displayName: 'Google Data Cloud AI Dev Kit' },
+    source: { source: 'local', path: './.agents/plugins/${PLUGIN_NAME}' },
     policy: { installation: 'AVAILABLE', authentication: 'ON_INSTALL' },
     category: 'Productivity'
 });


### PR DESCRIPTION
Instead of `./${PLUGIN_NAME}` it should be `./.agents/plugins/${PLUGIN_NAME}` for the source path.