### PR TITLE
ci: Add GitHub Action to verify Notebook MCP bundle

### DIFF
--- a/.github/workflows/notebook-mcp-check.yml
+++ b/.github/workflows/notebook-mcp-check.yml
@@ -1,0 +1,43 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Notebook MCP Bundle Check
+
+on:
+  pull_request:
+    paths:
+      - 'notebook_mcp/**'
+
+jobs:
+  check-bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@64745409647f540ba9c1a129988bd580887fb902 # v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: notebook_mcp
+
+      - name: Build bundle
+        run: npm run bundle
+        working-directory: notebook_mcp
+
+      - name: Check for uncommitted changes in bundle
+        run: git diff --exit-code notebook_mcp/dist/index.js


### PR DESCRIPTION
This Pull Request adds a GitHub Action workflow dedicated to the notebook_mcp server to ensure that contributors do not forget to build and commit the compiled distribution bundle.

Since we are pursuing a zero-install strategy via npx pointing directly at the repository source, it is absolutely critical that the generated asset notebook_mcp/dist/index.js honors the latest code edits.

What this workflow does:

1. Triggers exclusively on Pull Requests affecting anything inside the notebook_mcp/ directory.
2. Clones the branch and runs an active npm run bundle from source.
3. Compares the freshly generated script against the copy committed by the PR author via git diff --exit-code.
4. Stays passing if clean, but hard fails the build checks blocking merge if the developer forgot to run build locally!
