### PR TITLE
Rename plugin.json `mcp` key to `mcpServers` for Claude Code compatibility

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,5 +2,5 @@
   "name": "data-agent-kit-starter-pack",
   "version": "0.1.0",
   "description": "This plugin provides a specialized suite of skills for data engineers and database practitioners working on Google Cloud. It acts as an expert assistant, allowing you to use natural language prompts in your preferred coding agent to architect complex data pipelines, transform data with dbt, write Spark and BigQuery SQL notebooks, and orchestrate end-to-end workflows across GCP's data ecosystem.",
-  "mcp": "./.mcp.json"
+  "mcpServers": "./.mcp.json"
 }


### PR DESCRIPTION
## Summary

Claude Code's plugin loader rejects the `mcp` top-level key in `plugin.json` as unrecognized. Running `claude plugin validate` against this repo produces:

```
root: Unrecognized key: "mcp"
```

The Claude Code convention for referencing an MCP server config is `mcpServers`, which accepts the same `./.mcp.json` string path.

## Change

One-line rename in `.claude-plugin/plugin.json`:

```diff
-  "mcp": "./.mcp.json"
+  "mcpServers": "./.mcp.json"
```

## Validation

After the rename, `claude plugin validate` passes cleanly. The `.mcp.json` file itself is unchanged, so the MCP server configuration is identical.

## Notes

- I understand the `mcp` convention may be used by Gemini CLI — if you want to keep Gemini compat, you could close this PR and instead move the MCP reference out of `plugin.json` entirely. MCP configuration in `.mcp.json` can typically be auto-discovered by both CLIs without a pointer in `plugin.json`.
- Happy to iterate on the approach if there's a cross-CLI pattern you prefer.