### PR TITLE
feat: separate MCP configurations for Claude and Codex

### DIFF
--- a/.claude-mcp.json
+++ b/.claude-mcp.json
@@ -20,7 +20,7 @@
         "bigquery",
         "--stdio",
         "--user-agent-metadata",
-        "datacloud.codex"
+        "datacloud.claude"
       ],
       "env": {
         "BIGQUERY_LOCATION": "",
@@ -36,7 +36,7 @@
         "spanner",
         "--stdio",
         "--user-agent-metadata",
-        "datacloud.codex"
+        "datacloud.claude"
       ],
       "env": {
         "SPANNER_DATABASE": "",
@@ -54,7 +54,7 @@
         "alloydb-postgres-admin",
         "--stdio",
         "--user-agent-metadata",
-        "datacloud.codex"
+        "datacloud.claude"
       ],
       "env": {}
     },
@@ -67,7 +67,7 @@
         "alloydb-postgres",
         "--stdio",
         "--user-agent-metadata",
-        "datacloud.codex"
+        "datacloud.claude"
       ],
       "env": {
         "ALLOYDB_POSTGRES_CLUSTER": "",
@@ -89,7 +89,7 @@
         "cloud-sql-postgres-admin",
         "--stdio",
         "--user-agent-metadata",
-        "datacloud.codex"
+        "datacloud.claude"
       ],
       "env": {}
     },
@@ -102,7 +102,7 @@
         "cloud-sql-postgres",
         "--stdio",
         "--user-agent-metadata",
-        "datacloud.codex"
+        "datacloud.claude"
       ],
       "env": {
         "CLOUD_SQL_POSTGRES_DATABASE": "",
@@ -123,7 +123,7 @@
         "dataplex",
         "--stdio",
         "--user-agent-metadata",
-        "datacloud.codex"
+        "datacloud.claude"
       ],
       "env": {
         "DATAPLEX_PROJECT": ""
@@ -138,7 +138,7 @@
         "dataproc",
         "--stdio",
         "--user-agent-metadata",
-        "datacloud.codex"
+        "datacloud.claude"
       ],
       "env": {
         "DATAPROC_PROJECT": "",
@@ -154,7 +154,7 @@
         "serverless-spark",
         "--stdio",
         "--user-agent-metadata",
-        "datacloud.codex"
+        "datacloud.claude"
       ],
       "env": {
         "SERVERLESS_SPARK_PROJECT": "",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,5 +2,5 @@
   "name": "data-agent-kit-starter-pack",
   "version": "0.1.0",
   "description": "This plugin provides a specialized suite of skills for data engineers and database practitioners working on Google Cloud. It acts as an expert assistant, allowing you to use natural language prompts in your preferred coding agent to architect complex data pipelines, transform data with dbt, write Spark and BigQuery SQL notebooks, and orchestrate end-to-end workflows across GCP's data ecosystem.",
-  "mcp": "./.mcp.json"
+  "mcp": "./.claude-mcp.json"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,5 +2,5 @@
   "name": "data-agent-kit-starter-pack",
   "version": "0.1.0",
   "description": "This plugin provides a specialized suite of skills for data engineers and database practitioners working on Google Cloud. It acts as an expert assistant, allowing you to use natural language prompts in your preferred coding agent to architect complex data pipelines, transform data with dbt, write Spark and BigQuery SQL notebooks, and orchestrate end-to-end workflows across GCP's data ecosystem.",
-  "mcp": "./.claude-mcp.json"
+  "mcpServers": "./.claude-mcp.json"
 }


### PR DESCRIPTION
* Separate mcp configurations for claude and codex
* Update user agent in claude and codex mcp config files
* Tested claude on mac and windows with updated configuraiton. Explicitly tested that .claude-mcp.json is being picked up by temporarily deleting .mcp.json when in claude setup.