### PR TITLE
fix: use tags for codex installation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,11 @@ Run the `claude` command to start the agent, then follow these steps:
 
 **macOS / Linux:**
 ```bash
-# Pass the version as a parameter if you want to pin to a specific release
 curl -sSL https://raw.githubusercontent.com/gemini-cli-extensions/data-agent-kit-starter-pack/0.1.1/codex-install.sh | bash -s -- 0.1.1
 ```
 
 **Windows:**
 ```powershell
-# Pass the version as a parameter if you want to pin to a specific release
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/gemini-cli-extensions/data-agent-kit-starter-pack/0.1.1/codex-install.ps1))) -Tag 0.1.1
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ curl -sSL https://raw.githubusercontent.com/gemini-cli-extensions/data-agent-kit
 
 **Windows:**
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/gemini-cli-extensions/data-agent-kit-starter-pack/0.1.1/codex-install.ps1))) -Tag 0.1.1
+$env:CODEX_TAG="0.1.1"; irm https://raw.githubusercontent.com/gemini-cli-extensions/data-agent-kit-starter-pack/0.1.1/codex-install.ps1 | iex
 ```
 
 2. **Install the plugin in Codex:**

--- a/README.md
+++ b/README.md
@@ -78,12 +78,14 @@ Run the `claude` command to start the agent, then follow these steps:
 
 **macOS / Linux:**
 ```bash
-curl -sSL https://raw.githubusercontent.com/gemini-cli-extensions/data-agent-kit-starter-pack/0.1.1/codex-install.sh | bash
+# Pass the version as a parameter if you want to pin to a specific release
+curl -sSL https://raw.githubusercontent.com/gemini-cli-extensions/data-agent-kit-starter-pack/0.1.1/codex-install.sh | bash -s -- 0.1.1
 ```
 
 **Windows:**
 ```powershell
-irm https://raw.githubusercontent.com/gemini-cli-extensions/data-agent-kit-starter-pack/0.1.1/codex-install.ps1 | iex
+# Pass the version as a parameter if you want to pin to a specific release
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/gemini-cli-extensions/data-agent-kit-starter-pack/0.1.1/codex-install.ps1))) -Tag 0.1.1
 ```
 
 2. **Install the plugin in Codex:**

--- a/codex-install.ps1
+++ b/codex-install.ps1
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$Tag
+)
+
 $ErrorActionPreference = "Stop"
 
 $pluginName = "data-agent-kit-starter-pack"
@@ -56,24 +61,20 @@ Write-Host "--- $pluginName Installer for Codex ---"
 New-Item -ItemType Directory -Force -Path $pluginsRoot | Out-Null
 
 if (Test-Path $installDir) {
-    try {
-        & git -C $installDir rev-parse --is-inside-work-tree 2>$null | Out-Null
-    } catch {
-    }
-
-    if ($LASTEXITCODE -eq 0) {
-        Write-Host "Updating existing plugin at $installDir..."
-        Invoke-GitCommand -Arguments @("-C", $installDir, "pull")
-    } else {
-        Write-Host "Existing directory at $installDir is not a valid git checkout. Reinstalling..."
-        Remove-Item -LiteralPath $installDir -Recurse -Force
-        Write-Host "Cloning plugin to $installDir..."
-        Invoke-GitCommand -Arguments @("clone", $repoUrl, $installDir)
-    }
-} else {
-    Write-Host "Cloning plugin to $installDir..."
-    Invoke-GitCommand -Arguments @("clone", $repoUrl, $installDir)
+    Write-Host "Removing existing plugin at $installDir for clean install..."
+    Remove-Item -LiteralPath $installDir -Recurse -Force
 }
+
+if ($Tag) {
+    Write-Host "Cloning plugin version $Tag to $installDir..."
+    Invoke-GitCommand -Arguments @("clone", "--depth", "1", "--branch", $Tag, $repoUrl, $installDir)
+} else {
+    Write-Host "Cloning plugin default branch to $installDir..."
+    Invoke-GitCommand -Arguments @("clone", "--depth", "1", $repoUrl, $installDir)
+}
+
+Write-Host "Removing git metadata..."
+Remove-Item -LiteralPath (Join-Path $installDir ".git") -Recurse -Force
 
 if (-not (Test-Path $marketplaceFile)) {
     Write-Host "Creating new personal marketplace..."

--- a/codex-install.ps1
+++ b/codex-install.ps1
@@ -17,6 +17,10 @@ param(
     [string]$Tag
 )
 
+if (-not $Tag -and $env:CODEX_TAG) {
+    $Tag = $env:CODEX_TAG
+}
+
 $ErrorActionPreference = "Stop"
 
 $pluginName = "data-agent-kit-starter-pack"

--- a/codex-install.ps1
+++ b/codex-install.ps1
@@ -65,8 +65,13 @@ Write-Host "--- $pluginName Installer for Codex ---"
 New-Item -ItemType Directory -Force -Path $pluginsRoot | Out-Null
 
 if (Test-Path $installDir) {
-    Write-Host "Removing existing plugin at $installDir for clean install..."
-    Remove-Item -LiteralPath $installDir -Recurse -Force
+    $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+    $backupName = "$pluginName" + "_backup_" + $timestamp
+    $backupPath = Join-Path (Split-Path $installDir) $backupName
+    Write-Host "Backing up existing plugin to $backupPath..."
+    Rename-Item -LiteralPath $installDir -NewName $backupName
+    Write-Host "Notice: Your previous installation has been backed up to $backupPath."
+    Write-Host "You can delete it if you do not need it."
 }
 
 if ($Tag) {

--- a/codex-install.sh
+++ b/codex-install.sh
@@ -15,6 +15,8 @@
 
 set -e
 
+TAG=$1
+
 PLUGIN_NAME="data-agent-kit-starter-pack"
 REPO_URL="https://github.com/gemini-cli-extensions/data-agent-kit-starter-pack"
 INSTALL_DIR="$HOME/.agents/plugins/$PLUGIN_NAME"
@@ -25,12 +27,20 @@ echo "--- $PLUGIN_NAME Installer for Codex ---"
 # 1. Download/Update Plugin Content
 mkdir -p "$HOME/.agents/plugins"
 if [ -d "$INSTALL_DIR" ]; then
-    echo "Updating existing plugin at $INSTALL_DIR..."
-    cd "$INSTALL_DIR" && git pull
-else
-    echo "Cloning plugin to $INSTALL_DIR..."
-    git clone "$REPO_URL" "$INSTALL_DIR"
+    echo "Removing existing plugin at $INSTALL_DIR for clean install..."
+    rm -rf "$INSTALL_DIR"
 fi
+
+if [ -n "$TAG" ]; then
+    echo "Cloning plugin version $TAG to $INSTALL_DIR..."
+    git clone --depth 1 --branch "$TAG" "$REPO_URL" "$INSTALL_DIR"
+else
+    echo "Cloning plugin default branch to $INSTALL_DIR..."
+    git clone --depth 1 "$REPO_URL" "$INSTALL_DIR"
+fi
+
+echo "Removing git metadata..."
+rm -rf "$INSTALL_DIR/.git"
 
 # 2. Register with Codex Marketplace
 if [ ! -f "$MARKETPLACE_FILE" ]; then

--- a/codex-install.sh
+++ b/codex-install.sh
@@ -27,8 +27,11 @@ echo "--- $PLUGIN_NAME Installer for Codex ---"
 # 1. Download/Update Plugin Content
 mkdir -p "$HOME/.agents/plugins"
 if [ -d "$INSTALL_DIR" ]; then
-    echo "Removing existing plugin at $INSTALL_DIR for clean install..."
-    rm -rf "$INSTALL_DIR"
+    BACKUP_DIR="${INSTALL_DIR}_backup_$(date +%Y%m%d_%H%M%S)"
+    echo "Backing up existing plugin to $BACKUP_DIR..."
+    mv "$INSTALL_DIR" "$BACKUP_DIR"
+    echo "Notice: Your previous installation has been backed up to $BACKUP_DIR."
+    echo "You can delete it if you do not need it."
 fi
 
 if [ -n "$TAG" ]; then


### PR DESCRIPTION
Currently the codex installation scripts are installing the latest main commit by default. There's other issues like if the user makes changes to the plugin directory, the `git pull` will fail because there are uncommitted changes in the directory.

- updated the codex installation scripts to use a variable that holds the release-tag
- the scripts use the release tag value to clone specific release tag branch
- updated README to reference the new command with the tag

other changes to the scripts : 
- getting a shallow clone as we don't need to download the whole git history
- backing up the existing plugin directory before cloning to start a clean install
- after cloning, removes the .git folder since we don't need git functionality in the folder