### PR TITLE
docs: update notebook guidance criteria phrasing and clean up whitespace

### DIFF
--- a/skills/accidental-data-loss-prevention/SKILL.md
+++ b/skills/accidental-data-loss-prevention/SKILL.md
@@ -30,4 +30,3 @@ metadata:
 3.  **Wait**: Only proceed if the user provides clear, affirmative consent in
     the conversation.
 
-TEST1

--- a/skills/accidental-data-loss-prevention/SKILL.md
+++ b/skills/accidental-data-loss-prevention/SKILL.md
@@ -30,4 +30,4 @@ metadata:
 3.  **Wait**: Only proceed if the user provides clear, affirmative consent in
     the conversation.
 
-TEST
+TEST1

--- a/skills/accidental-data-loss-prevention/SKILL.md
+++ b/skills/accidental-data-loss-prevention/SKILL.md
@@ -29,3 +29,5 @@ metadata:
     -   A request for their **explicit approval** to proceed.
 3.  **Wait**: Only proceed if the user provides clear, affirmative consent in
     the conversation.
+
+TEST

--- a/skills/developing-with-bigquery/SKILL.md
+++ b/skills/developing-with-bigquery/SKILL.md
@@ -36,7 +36,7 @@ Guidelines for generating valid BigFrames code for data manipulation, model
 development, and visualization. - **Guide**:
 [BIGFRAMES.md](references/BIGFRAMES.md)
 
-Bigframes should be the default library/tool as it is more efficient than using
+BigFrames should be the default library/tool as it is more efficient than using
 the BigQuery Python client library.
 
 ### 3. BigQuery ML & AI Functions (BQML SQL)

--- a/skills/developing-with-bigquery/SKILL.md
+++ b/skills/developing-with-bigquery/SKILL.md
@@ -8,7 +8,7 @@ description: |
     3. BigQuery ML/AI functions.
 license: Apache-2.0
 metadata:
-   version: v1
+  version: v1
   publisher: google
 ---
 

--- a/skills/developing-with-bigquery/SKILL.md
+++ b/skills/developing-with-bigquery/SKILL.md
@@ -8,7 +8,7 @@ description: |
     3. BigQuery ML/AI functions.
 license: Apache-2.0
 metadata:
-  version: v1
+   version: v1
   publisher: google
 ---
 

--- a/skills/gcp-dataflow/SKILL.md
+++ b/skills/gcp-dataflow/SKILL.md
@@ -100,7 +100,7 @@ Follow the Flex Templates section below.
 
 ## Diagnostics & Troubleshooting
 
-YOU MUST use this section when the user asks about performance of their dataflow
+You MUST use this section when the user asks about performance of their dataflow
 pipelines. This can be used to debug issues like pipeline slowness, pipeline
 failures, etc.
 

--- a/skills/notebook-guidance/SKILL.md
+++ b/skills/notebook-guidance/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 Before choosing to use a notebook, evaluate the task complexity using these
 heuristics.
 
-Use a notebook if you meet at least one of these 3 criteria:
+Use a notebook if you meet at least one of these 3 criterias:
 
 *   📈 **Data Insights & Storytelling**: Use a notebook for any request to "give
     insights", "find trends", "explore data", or "analyze data". These tasks

--- a/skills/notebook-guidance/SKILL.md
+++ b/skills/notebook-guidance/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 Before choosing to use a notebook, evaluate the task complexity using these
 heuristics.
 
-Use a notebook if you meet at least one of these 3 criteria:
+Use a notebook if you meet at least one of these three criterias:
 
 *   📈 **Data Insights & Storytelling**: Use a notebook for any request to "give
     insights", "find trends", "explore data", or "analyze data". These tasks

--- a/skills/notebook-guidance/SKILL.md
+++ b/skills/notebook-guidance/SKILL.md
@@ -20,7 +20,7 @@ metadata:
 Before choosing to use a notebook, evaluate the task complexity using these
 heuristics.
 
-Use a notebook if you meet at least one of these 3 criterias:
+Use a notebook if you meet at least one of these 3 criteria:
 
 *   📈 **Data Insights & Storytelling**: Use a notebook for any request to "give
     insights", "find trends", "explore data", or "analyze data". These tasks


### PR DESCRIPTION
This PR updates the phrasing in the notebook guidance documentation and performs minor whitespace cleanups.

### Changes:
* **Notebook Guidance**: Adjusted phrasing in `skills/notebook-guidance/SKILL.md`.
* **Accidental Data Loss Prevention**: Cleaned up whitespace at the end of `skills/accidental-data-loss-prevention/SKILL.md`.