### PR TITLE
ci: remove paths filter from pull_request trigger on mcp-check

### DIFF
--- a/.github/workflows/mcp-check.yml
+++ b/.github/workflows/mcp-check.yml
@@ -16,8 +16,6 @@ name: Notebook MCP Bundle Check
 
 on:
   pull_request:
-    paths:
-      - 'mcp/**'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'


### PR DESCRIPTION
This PR removes the paths filter from the pull_request trigger in the mcp-check workflow, ensuring it runs on all pull requests regardless of changed files.