### PR TITLE
feat: rename plugin to dak and remove toolbox from mcp server names for abiding to 64 char limit in some platforms

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "plugins": [
     {
-      "name": "data-agent-kit-starter-pack",
+      "name": "dak",
       "source": {
         "source": "local",
         "path": "./"

--- a/.claude-mcp.json
+++ b/.claude-mcp.json
@@ -24,7 +24,7 @@
         "DATA_CLOUD_CURR_IDE_NAME"
       ]
     },
-    "datacloud_bigquery_toolbox": {
+    "bigquery": {
       "command": "npx",
       "args": [
         "-y",
@@ -40,7 +40,7 @@
         "BIGQUERY_PROJECT": "${user_config.PROJECT_ID}"
       }
     },
-    "datacloud_spanner_toolbox": {
+    "spanner": {
       "command": "npx",
       "args": [
         "-y",
@@ -58,7 +58,7 @@
         "SPANNER_PROJECT": "${user_config.PROJECT_ID}"
       }
     },
-    "datacloud_alloydb-postgres-admin_toolbox": {
+    "alloydb-postgres-admin": {
       "command": "npx",
       "args": [
         "-y",
@@ -71,7 +71,7 @@
       ],
       "env": {}
     },
-    "datacloud_alloydb-postgres_toolbox": {
+    "alloydb-postgres": {
       "command": "npx",
       "args": [
         "-y",
@@ -93,7 +93,7 @@
         "ALLOYDB_POSTGRES_USER": ""
       }
     },
-    "datacloud_cloud-sql-postgresql-admin_toolbox": {
+    "cloud-sql-postgresql-admin": {
       "command": "npx",
       "args": [
         "-y",
@@ -106,7 +106,7 @@
       ],
       "env": {}
     },
-    "datacloud_cloud-sql-postgresql_toolbox": {
+    "cloud-sql-postgresql": {
       "command": "npx",
       "args": [
         "-y",
@@ -127,7 +127,7 @@
         "CLOUD_SQL_POSTGRES_USER": ""
       }
     },
-    "datacloud_knowledge_catalog_toolbox": {
+    "knowledge_catalog": {
       "command": "npx",
       "args": [
         "-y",
@@ -142,7 +142,7 @@
         "DATAPLEX_PROJECT": "${user_config.PROJECT_ID}"
       }
     },
-    "datacloud_dataproc_toolbox": {
+    "dataproc": {
       "command": "npx",
       "args": [
         "-y",
@@ -158,7 +158,7 @@
         "DATAPROC_REGION": "${user_config.GCP_REGION}"
       }
     },
-    "datacloud_serverless-spark_toolbox": {
+    "serverless-spark": {
       "command": "npx",
       "args": [
         "-y",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "plugins": [
     {
-      "name": "data-agent-kit-starter-pack",
+      "name": "dak",
       "source": "./",
       "description": "This plugin provides a specialized suite of skills for data engineers and database practitioners working on Google Cloud. It acts as an expert assistant, allowing you to use natural language prompts in your preferred coding agent to architect complex data pipelines, transform data with dbt, write Spark and BigQuery SQL notebooks, and orchestrate end-to-end workflows across GCP's data ecosystem."
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "data-agent-kit-starter-pack",
+  "name": "dak",
   "version": "0.4.0",
   "description": "This plugin provides a specialized suite of skills for data engineers and database practitioners working on Google Cloud. It acts as an expert assistant, allowing you to use natural language prompts in your preferred coding agent to architect complex data pipelines, transform data with dbt, write Spark and BigQuery SQL notebooks, and orchestrate end-to-end workflows across GCP's data ecosystem.",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "data-agent-kit-starter-pack",
+  "name": "dak",
   "version": "0.4.0",
   "description": "This plugin provides a specialized suite of skills for data engineers and database practitioners working on Google Cloud. It acts as an expert assistant, allowing you to use natural language prompts in your preferred coding agent to architect complex data pipelines, transform data with dbt, write Spark and BigQuery SQL notebooks, and orchestrate end-to-end workflows across GCP's data ecosystem.",
   "skills": "./skills/",

--- a/.mcp.json
+++ b/.mcp.json
@@ -24,7 +24,7 @@
         "DATA_CLOUD_CURR_IDE_NAME"
       ]
     },
-    "datacloud_bigquery_toolbox": {
+    "bigquery": {
       "command": "npx",
       "args": [
         "-y",
@@ -40,7 +40,7 @@
         "BIGQUERY_PROJECT": "$PROJECT_ID"
       }
     },
-    "datacloud_spanner_toolbox": {
+    "spanner": {
       "command": "npx",
       "args": [
         "-y",
@@ -58,7 +58,7 @@
         "SPANNER_PROJECT": "$PROJECT_ID"
       }
     },
-    "datacloud_alloydb-postgres-admin_toolbox": {
+    "alloydb-postgres-admin": {
       "command": "npx",
       "args": [
         "-y",
@@ -71,7 +71,7 @@
       ],
       "env": {}
     },
-    "datacloud_alloydb-postgres_toolbox": {
+    "alloydb-postgres": {
       "command": "npx",
       "args": [
         "-y",
@@ -93,7 +93,7 @@
         "ALLOYDB_POSTGRES_USER": ""
       }
     },
-    "datacloud_cloud-sql-postgresql-admin_toolbox": {
+    "cloud-sql-postgresql-admin": {
       "command": "npx",
       "args": [
         "-y",
@@ -106,7 +106,7 @@
       ],
       "env": {}
     },
-    "datacloud_cloud-sql-postgresql_toolbox": {
+    "cloud-sql-postgresql": {
       "command": "npx",
       "args": [
         "-y",
@@ -127,7 +127,7 @@
         "CLOUD_SQL_POSTGRES_USER": ""
       }
     },
-    "datacloud_knowledge_catalog_toolbox": {
+    "knowledge_catalog": {
       "command": "npx",
       "args": [
         "-y",
@@ -142,7 +142,7 @@
         "DATAPLEX_PROJECT": "$PROJECT_ID"
       }
     },
-    "datacloud_dataproc_toolbox": {
+    "dataproc": {
       "command": "npx",
       "args": [
         "-y",
@@ -158,7 +158,7 @@
         "DATAPROC_REGION": "$GCP_REGION"
       }
     },
-    "datacloud_serverless-spark_toolbox": {
+    "serverless-spark": {
       "command": "npx",
       "args": [
         "-y",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
-  "name": "data-agent-kit-starter-pack",
+  "name": "dak",
   "version": "0.4.0",
   "description": "This plugin provides a specialized suite of skills for data engineers and database practitioners working on Google Cloud. It acts as an expert assistant, allowing you to use natural language prompts in your preferred coding agent to architect complex data pipelines, transform data with dbt, write Spark and BigQuery SQL notebooks, and orchestrate end-to-end workflows across GCP's data ecosystem.",
   "mcpServers": {
@@ -21,7 +21,7 @@
       ],
       "env": {}
     },
-    "datacloud_bigquery_toolbox": {
+    "bigquery": {
       "command": "npx",
       "args": [
         "-y",
@@ -37,7 +37,7 @@
         "BIGQUERY_PROJECT": "$PROJECT_ID"
       }
     },
-    "datacloud_spanner_toolbox": {
+    "spanner": {
       "command": "npx",
       "args": [
         "-y",
@@ -55,7 +55,7 @@
         "SPANNER_PROJECT": "$PROJECT_ID"
       }
     },
-    "datacloud_alloydb-postgres-admin_toolbox": {
+    "alloydb-postgres-admin": {
       "command": "npx",
       "args": [
         "-y",
@@ -68,7 +68,7 @@
       ],
       "env": {}
     },
-    "datacloud_alloydb-postgres_toolbox": {
+    "alloydb-postgres": {
       "command": "npx",
       "args": [
         "-y",
@@ -90,7 +90,7 @@
         "ALLOYDB_POSTGRES_USER": ""
       }
     },
-    "datacloud_cloud-sql-postgresql-admin_toolbox": {
+    "cloud-sql-postgresql-admin": {
       "command": "npx",
       "args": [
         "-y",
@@ -103,7 +103,7 @@
       ],
       "env": {}
     },
-    "datacloud_cloud-sql-postgresql_toolbox": {
+    "cloud-sql-postgresql": {
       "command": "npx",
       "args": [
         "-y",
@@ -124,7 +124,7 @@
         "CLOUD_SQL_POSTGRES_USER": ""
       }
     },
-    "datacloud_knowledge_catalog_toolbox": {
+    "knowledge_catalog": {
       "command": "npx",
       "args": [
         "-y",
@@ -139,7 +139,7 @@
         "DATAPLEX_PROJECT": "$PROJECT_ID"
       }
     },
-    "datacloud_dataproc_toolbox": {
+    "dataproc": {
       "command": "npx",
       "args": [
         "-y",
@@ -155,7 +155,7 @@
         "DATAPROC_REGION": "$GCP_REGION"
       }
     },
-    "datacloud_serverless-spark_toolbox": {
+    "serverless-spark": {
       "command": "npx",
       "args": [
         "-y",


### PR DESCRIPTION
This PR renames the plugin inside `plugin.json` and `marketplace.json` files to `dak` and removes the `datacloud_` prefix and `_toolbox` suffix from the MCP server names in the configuration files (`.claude-mcp.json`, `.mcp.json`, `gemini-extension.json`).